### PR TITLE
Added live streaming

### DIFF
--- a/NetPodcast.sln
+++ b/NetPodcast.sln
@@ -19,9 +19,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Podcast.Ingestion.Worker", 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Actions", "Actions", "{1B0A13EE-F8DB-4734-ACE6-FD5EB19BA5D3}"
 	ProjectSection(SolutionItems) = preProject
-		.github\workflows\podcast-api.yml = .github\workflows\podcast-api.yml
-		.github\workflows\podcast-hub.yml = .github\workflows\podcast-hub.yml
-		.github\workflows\podcast-web.yml = .github\workflows\podcast-web.yml
+		.github\workflows\environment_create.yml = .github\workflows\environment_create.yml
+		.github\workflows\environment_delete.yml = .github\workflows\environment_delete.yml
+		.github\workflows\environment_update.yml = .github\workflows\environment_update.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Deploy", "Deploy", "{CE88241B-B740-4E6A-9D73-7C0B9F7CC069}"

--- a/src/Services/Podcasts/Podcast.API/Program.cs
+++ b/src/Services/Podcasts/Podcast.API/Program.cs
@@ -4,16 +4,11 @@ using System.Threading.RateLimiting;
 using Asp.Versioning;
 using Asp.Versioning.Conventions;
 using Azure.Monitor.OpenTelemetry.Exporter;
-using Azure.Storage.Queues;
 using Microsoft.AspNetCore.RateLimiting;
-using Microsoft.EntityFrameworkCore;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
-using Podcast.API.Routes;
-using Podcast.Infrastructure.Data;
 using Podcast.Infrastructure.Http;
-using Podcast.Infrastructure.Http.Feeds;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Microsoft.Identity.Web;
 
@@ -156,6 +151,7 @@ var shows = app.MapGroup("/shows");
 var categories = app.MapGroup("/categories");
 var episodes = app.MapGroup("/episodes");
 var feeds = app.MapGroup("/feeds");
+var liveStreams = app.MapGroup("/livestreams");
 
 shows
     .MapShowsApi()
@@ -171,6 +167,12 @@ categories
 
 episodes
     .MapEpisodesApi()
+    .WithApiVersionSet(versionSet)
+    .MapToApiVersion(1.0)
+    .MapToApiVersion(2.0);
+
+liveStreams
+    .MapLiveStreamApi()
     .WithApiVersionSet(versionSet)
     .MapToApiVersion(1.0)
     .MapToApiVersion(2.0);

--- a/src/Services/Podcasts/Podcast.API/Routes/LiveStreamApi.cs
+++ b/src/Services/Podcasts/Podcast.API/Routes/LiveStreamApi.cs
@@ -1,0 +1,49 @@
+using Podcast.Infrastructure.Http;
+
+namespace Podcast.API.Routes;
+
+public static class LiveStreamApi
+{
+    public static RouteGroupBuilder MapLiveStreamApi(this RouteGroupBuilder group)
+    {
+        group.MapGet("/", GetAllLiveStreams).WithName("GetLiveStreams");
+        group.MapGet("/{id}", GetLiveStreamById).WithName("GetLiveStreamsById");
+        return group;
+    }
+
+    public static async ValueTask<Ok<List<ShowDto>>> GetAllLiveStreams(int limit, string? term, Guid? categoryId, CancellationToken cancellationToken, PodcastDbContext podcastDbContext, ShowClient showClient)
+    {
+        var showsQuery = podcastDbContext.Shows.Include(show => show.Feed!.Categories)
+        .ThenInclude(x => x.Category)
+        .AsQueryable();
+
+        if (!string.IsNullOrEmpty(term))
+            showsQuery = showsQuery.Where(show => show.Title.Contains(term));
+
+        if (categoryId is not null)
+            showsQuery = showsQuery.Where(show =>
+                show.Feed!.Categories.Any(y => y.CategoryId == categoryId));
+
+        var shows = await showsQuery.OrderByDescending(show => show.Feed!.IsFeatured)
+            .ThenBy(x => x.Title)
+            .Take(limit)
+            .Select(x => new ShowDto(x))
+            .ToListAsync(cancellationToken);
+
+        List<ShowDto> showsWithValidLinks = Task.WhenAll(shows.Select(async show => await showClient.CheckLink(show.Link) ? show : null)).Result.Where(show => show is not null).ToList()!;
+        return TypedResults.Ok(showsWithValidLinks);
+    }
+
+
+    public static async ValueTask<Results<NotFound, Ok<ShowDto>>> GetLiveStreamById(PodcastDbContext podcastDbContext, Guid id, CancellationToken cancellationToken)
+    {
+        var show = await podcastDbContext.Shows
+            .Include(show => show.Episodes.OrderByDescending(episode => episode.Published))
+            .Include(show => show.Feed!.Categories)
+            .ThenInclude(feed => feed.Category)
+            .Where(x => x.Id == id)
+            .Select(show => new ShowDto(show))
+            .FirstOrDefaultAsync(cancellationToken);
+        return show == null ? TypedResults.NotFound() : TypedResults.Ok(show);
+    }
+}

--- a/src/Services/Podcasts/Podcast.API/Routes/ShowsApi.cs
+++ b/src/Services/Podcasts/Podcast.API/Routes/ShowsApi.cs
@@ -1,8 +1,4 @@
-﻿using Microsoft.AspNetCore.Http.HttpResults;
-using Microsoft.EntityFrameworkCore;
-using Podcast.API.Models;
-using Podcast.Infrastructure.Data;
-using Podcast.Infrastructure.Http;
+﻿using Podcast.Infrastructure.Http;
 
 namespace Podcast.API.Routes;
 

--- a/src/Services/Podcasts/Podcast.Infrastructure/Data/DTOs/ShowDto.cs
+++ b/src/Services/Podcasts/Podcast.Infrastructure/Data/DTOs/ShowDto.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Podcast.Infrastructure.Data.Models;
+﻿using Podcast.Infrastructure.Data.Models;
 
 namespace Podcast.API.Models;
 
@@ -19,6 +16,7 @@ public record ShowDto
         Email = show.Email;
         Language = show.Language;
         IsFeatured = show.Feed!.IsFeatured;
+        IsLiveStreamed = show.Link?.Contains("youtube.com") ?? false;
         Categories = show.Feed.Categories
             .Select(category => new CategoryDto(category.Category!.Id, category.Category.Genre)).ToList();
         Episodes = show.Episodes.Select(episode =>
@@ -36,6 +34,7 @@ public record ShowDto
     public string Email { get; }
     public string Language { get; }
     public bool IsFeatured { get; set; }
+    public bool IsLiveStreamed { get; set; }
     public List<CategoryDto> Categories { get; }
     public List<EpisodeDetailDto> Episodes { get; set; }
 

--- a/src/Web/Server/Pages/Landing.cshtml
+++ b/src/Web/Server/Pages/Landing.cshtml
@@ -172,6 +172,9 @@
                     </svg>
                 </li>
                 <li>
+                    <a href="#features" onclick="removeClass()" title="Live Streaming">Live Streaming</a>
+                </li>
+                <li>
                     <a href="#features" onclick="removeClass()" title="Features">Features</a>
                 </li>
                 <li>


### PR DESCRIPTION
This PR adds support for live streaming podcasts:
 - Adds new live streaming api
 - Updates shows and feeds objects to support live streaming
 - Adds new Live Streaming header menu item to home page
 - Updates cards on the shows page to indicate live streaming support